### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Genderselfidentify/BAO/Gender.php
+++ b/CRM/Genderselfidentify/BAO/Gender.php
@@ -4,7 +4,7 @@ class CRM_Genderselfidentify_BAO_Gender {
 
   /**
    * @return int
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function getCustomFieldId() {
     static $id;
@@ -22,7 +22,7 @@ class CRM_Genderselfidentify_BAO_Gender {
   /**
    * @param string $ret
    * @return int
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function otherOption($ret = 'value') {
     static $option;
@@ -41,7 +41,7 @@ class CRM_Genderselfidentify_BAO_Gender {
    *
    * @param int $contactId
    * @return string
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function get($contactId) {
     if (!$contactId) {
@@ -58,7 +58,7 @@ class CRM_Genderselfidentify_BAO_Gender {
   /**
    * @param string $input
    * @return int
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function match($input) {
     $input = trim($input);

--- a/genderselfidentify.php
+++ b/genderselfidentify.php
@@ -88,7 +88,7 @@ function genderselfidentify_civicrm_disable() {
     ));
   }
   // If custom data doesn't exist, ignore
-  catch (API_Exception $e) {}
+  catch (CRM_Core_Exception $e) {}
 }
 
 /**
@@ -276,7 +276,7 @@ function genderselfidentify_civicrm_searchColumns($objectName, &$headers, &$rows
  * Add "Other" gender option if it doesn't exist
  * Ensure it is enabled and reserved if it already exists
  *
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function _genderselfidentify_add_other_option() {
   $options = civicrm_api3('OptionValue', 'get', array('option_group_id' => 'gender'));


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.